### PR TITLE
Create basic Flask dashboard app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# Dashboard
-Trying to build a dashboard
+# Solar Monitoring Dashboard
+
+This project is a simple Flask application that allows you to monitor and store design data for solar panels. It uses a SQLite database to keep track of each panel's ID, location, and current power output.
+
+## Features
+
+- Add new solar panel records via a web form
+- View existing data in a table
+- Responsive layout using Bootstrap
+
+## Requirements
+
+- Python 3.8+
+- `pip` package manager
+
+## Setup
+
+1. Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the application:
+
+```bash
+python -m solar_dashboard.app
+```
+
+The app will start on <http://localhost:5000> by default.
+
+## Project Structure
+
+```
+solar_dashboard/
+├── app.py              # Flask application
+├── templates/
+│   └── index.html      # Dashboard page
+└── static/             # Directory for future static assets
+```
+
+Feel free to extend the dashboard with additional pages or API endpoints as needed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/solar_dashboard/app.py
+++ b/solar_dashboard/app.py
@@ -1,0 +1,39 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+import os
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///solar.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+class DesignData(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    panel_id = db.Column(db.String(50), nullable=False)
+    location = db.Column(db.String(100), nullable=False)
+    power_output = db.Column(db.Float, nullable=False)
+
+def create_tables():
+    with app.app_context():
+        db.create_all()
+
+@app.route('/')
+def index():
+    data = DesignData.query.all()
+    return render_template('index.html', data=data)
+
+@app.route('/add', methods=['POST'])
+def add_data():
+    panel_id = request.form['panel_id']
+    location = request.form['location']
+    power_output = request.form['power_output']
+    new_data = DesignData(panel_id=panel_id, location=location, power_output=power_output)
+    db.session.add(new_data)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    create_tables()
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=True)

--- a/solar_dashboard/templates/index.html
+++ b/solar_dashboard/templates/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Solar Monitoring Dashboard</title>
+</head>
+<body>
+<div class="container mt-4">
+    <h1 class="mb-4">Solar Monitoring Dashboard</h1>
+    <form action="{{ url_for('add_data') }}" method="POST" class="row g-3 mb-4">
+        <div class="col-md-4">
+            <input type="text" name="panel_id" class="form-control" placeholder="Panel ID" required>
+        </div>
+        <div class="col-md-4">
+            <input type="text" name="location" class="form-control" placeholder="Location" required>
+        </div>
+        <div class="col-md-3">
+            <input type="number" step="any" name="power_output" class="form-control" placeholder="Power Output (kW)" required>
+        </div>
+        <div class="col-md-1">
+            <button type="submit" class="btn btn-primary">Add</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Panel ID</th>
+                <th>Location</th>
+                <th>Power Output (kW)</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for entry in data %}
+            <tr>
+                <td>{{ entry.id }}</td>
+                <td>{{ entry.panel_id }}</td>
+                <td>{{ entry.location }}</td>
+                <td>{{ entry.power_output }}</td>
+            </tr>
+        {% else %}
+            <tr>
+                <td colspan="4" class="text-center">No data available</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build out a simple Flask app for monitoring solar panel data
- store design data in a SQLite database
- add Bootstrap-based dashboard page
- document setup and running instructions

## Testing
- `pip install -r requirements.txt`
- `python -m solar_dashboard.app` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6852c13b93f4833187c775b2eb3c5ecc